### PR TITLE
Don't fail if there is at least one error wrapping (fixes #5)

### DIFF
--- a/errorlint/testdata/src/fmterrorf/fmterrorf.go
+++ b/errorlint/testdata/src/fmterrorf/fmterrorf.go
@@ -21,9 +21,10 @@ func DoubleNonWrappingVerb() error {
 }
 
 func ErrorAtLeastOneWrap() error {
-	ErrFoo := errors.New("foo")
-	ErrBar := errors.New("bar")
-	return fmt.Errorf("%w, %v", ErrFoo, ErrBar)
+	err1 := errors.New("oops1")
+	err2 := errors.New("oops2")
+	err3 := errors.New("oops3")
+	return fmt.Errorf("%v, %w, %v", err1, err2, err3)
 }
 
 func ErrorStringFormat() error {


### PR DESCRIPTION
This is a follow-up on issue #5 that was partially fixed with https://github.com/polyfloyd/go-errorlint/commit/32ea8681d64bf4ccd98f555311a8bc1a09f3a976.

This PR should fix the cases when the error wrapped is not the first one in the list of arguments (e.g.  `fmt.Errorf("%v, %w", err1, err2)`).

Thanks!