### PR TITLE
Ignore io.EOF comparison for (*bufio.Reader).ReadLine

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -17,6 +17,7 @@ var allowedErrors = []struct {
 	{err: "io.EOF", fun: "(*bufio.Reader).Read"},
 	{err: "io.EOF", fun: "(*bufio.Reader).ReadByte"},
 	{err: "io.EOF", fun: "(*bufio.Reader).ReadBytes"},
+	{err: "io.EOF", fun: "(*bufio.Reader).ReadLine"},
 	{err: "io.EOF", fun: "(*bufio.Reader).ReadSlice"},
 	{err: "io.EOF", fun: "(*bufio.Reader).ReadString"},
 	{err: "io.EOF", fun: "(*bufio.Scanner).Scan"},


### PR DESCRIPTION
Although the documentation for (*bufio.Reader).ReadLine
do not mention io.EOF explicitly, this function can also
return it -- the implementation [1] user ReadSlice() which
is documented to return io.EOF.

[1] https://golang.org/src/bufio/bufio.go?s=10168:10235#L378

Found in https://github.com/opencontainers/runc/pull/3062/commits/02c23c4c13ec65bb0872484905c01064c31c74ae

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>