### PR TITLE
Allow comparisons with http.ErrServerClosed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /go-errorlint
+/.idea

--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -40,6 +40,15 @@ var allowedErrors = []struct {
 	{err: "io.ErrShortBuffer", fun: "io.ReadAtLeast"},
 	{err: "io.ErrUnexpectedEOF", fun: "io.ReadAtLeast"},
 	{err: "io.ErrUnexpectedEOF", fun: "io.ReadFull"},
+	// pkg/net/http
+	{err: "http.ErrServerClosed", fun: "(*net/http.Server).ListenAndServe"},
+	{err: "http.ErrServerClosed", fun: "(*net/http.Server).ListenAndServeTLS"},
+	{err: "http.ErrServerClosed", fun: "(*net/http.Server).Serve"},
+	{err: "http.ErrServerClosed", fun: "(*net/http.Server).ServeTLS"},
+	{err: "http.ErrServerClosed", fun: "http.ListenAndServe"},
+	{err: "http.ErrServerClosed", fun: "http.ListenAndServeTLS"},
+	{err: "http.ErrServerClosed", fun: "http.Serve"},
+	{err: "http.ErrServerClosed", fun: "http.ServeTLS"},
 	// pkg/os
 	{err: "io.EOF", fun: "(*os.File).Read"},
 	{err: "io.EOF", fun: "(*os.File).ReadAt"},

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 )
 
@@ -103,4 +104,32 @@ func (c CompressedFile) Read(p []byte) (int, error) {
 		return n, io.EOF
 	}
 	return n, fmt.Errorf("can't read from reader")
+}
+
+func HTTPErrServerClosed(s *http.Server) error {
+	if err := s.Serve(nil); err != http.ErrServerClosed {
+		return err
+	}
+	if err := s.ServeTLS(nil, "", ""); err != http.ErrServerClosed {
+		return err
+	}
+	if err := s.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	if err := s.ListenAndServeTLS("", ""); err != http.ErrServerClosed {
+		return err
+	}
+	if err := http.Serve(nil, nil); err != http.ErrServerClosed {
+		return err
+	}
+	if err := http.ServeTLS(nil, nil, "", ""); err != http.ErrServerClosed {
+		return err
+	}
+	if err := http.ListenAndServe("", nil); err != http.ErrServerClosed {
+		return err
+	}
+	if err := http.ListenAndServeTLS("", "", "", nil); err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
It is a well-known and documented behavior that when calling the [Shutdown] method of an [http.Server], the call to [Serve], [ListenAndServe] and their TLS variations return the `ErrServerClosed` error value, unwrapped. This PR adds these methods, along with their free functions shorthands to the list of allowed errors for comparison.

[Shutdown]: https://pkg.go.dev/net/http#Server.Shutdown
[http.Server]: https://pkg.go.dev/net/http#Server
[Serve]: https://pkg.go.dev/net/http#Server.Serve
[ListenAndServe]: https://pkg.go.dev/net/http#Server.ListenAndServe