### PR TITLE
Permit switch err with case nil or default

### DIFF
--- a/errorlint/testdata/src/errorsis/errorsis.go
+++ b/errorlint/testdata/src/errorsis/errorsis.go
@@ -82,6 +82,16 @@ func CompareSwitch() {
 	}
 }
 
+func CompareSwitchNilDefault() {
+	err := doThing()
+	switch err {
+	case nil:
+		fmt.Println("success")
+	default:
+		fmt.Println("failure")
+	}
+}
+
 func CompareSwitchInline() {
 	switch doThing() { // want `switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors`
 	case ErrFoo:

--- a/errorlint/testdata/src/errorsis/errorsis.go
+++ b/errorlint/testdata/src/errorsis/errorsis.go
@@ -77,12 +77,14 @@ func NotEqualOperatorYoda() {
 func CompareSwitch() {
 	err := doThing()
 	switch err { // want `switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors`
+	case nil:
+		fmt.Println("nil")
 	case ErrFoo:
 		fmt.Println("ErrFoo")
 	}
 }
 
-func CompareSwitchNilDefault() {
+func CompareSwitchSafe() {
 	err := doThing()
 	switch err {
 	case nil:


### PR DESCRIPTION
I'm not sure I'd call it great code, but I hit a false positive on code like this:

```go
switch err {
case nil:
	...
default:
	...
}
```

These checks clearly don't care whether an error is wrapped. Accordingly this PR extends the SwitchStmt logic to only emit a lint when at least one clause is neither `case nil` or `default`.