### PR TITLE
Allow `io.ReadFull` to return unwrapped `io.EOF`

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -40,6 +40,7 @@ var allowedErrors = []struct {
 	{err: "io.ErrClosedPipe", fun: "(*io.PipeWriter).Write"},
 	{err: "io.ErrShortBuffer", fun: "io.ReadAtLeast"},
 	{err: "io.ErrUnexpectedEOF", fun: "io.ReadAtLeast"},
+	{err: "io.EOF", fun: "io.ReadFull"},
 	{err: "io.ErrUnexpectedEOF", fun: "io.ReadFull"},
 	// pkg/net/http
 	{err: "http.ErrServerClosed", fun: "(*net/http.Server).ListenAndServe"},

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -102,6 +102,9 @@ func IoReadAtLeast(r io.Reader) {
 func IoReadFull(r io.Reader) {
 	var buf [4096]byte
 	_, err := io.ReadFull(r, buf[:])
+	if err == io.EOF {
+		fmt.Println(err)
+	}
 	if err == io.ErrUnexpectedEOF {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
It is documented to do so.