### PR TITLE
Ignore io.EOF from some more sources

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -35,8 +35,15 @@ var allowedErrors = []struct {
 	{err: "io.EOF", fun: "(*bytes.Reader).ReadString"},
 	// pkg/database/sql
 	{err: "sql.ErrNoRows", fun: "(*database/sql.Row).Scan"},
+	// pkg/debug/elf
+	{err: "io.EOF", fun: "elf.Open"},
+	{err: "io.EOF", fun: "elf.NewFile"},
 	// pkg/io
 	{err: "io.EOF", fun: "(io.Reader).Read"},
+	{err: "io.EOF", fun: "(io.ReaderAt).ReadAt"},
+	{err: "io.EOF", fun: "(*io.LimitedReader).Read"},
+	{err: "io.EOF", fun: "(*io.SectionReader).Read"},
+	{err: "io.EOF", fun: "(*io.SectionReader).ReadAt"},
 	{err: "io.ErrClosedPipe", fun: "(*io.PipeWriter).Write"},
 	{err: "io.ErrShortBuffer", fun: "io.ReadAtLeast"},
 	{err: "io.ErrUnexpectedEOF", fun: "io.ReadAtLeast"},

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"database/sql"
+	"debug/elf"
 	"errors"
 	"fmt"
 	"io"
@@ -107,6 +108,48 @@ func IoReadFull(r io.Reader) {
 		fmt.Println(err)
 	}
 	if err == io.ErrUnexpectedEOF {
+		fmt.Println(err)
+	}
+}
+
+func IoReaderAt(r io.ReaderAt) {
+	var buf [4096]byte
+	_, err := r.ReadAt(buf[:], 0)
+	if err == io.EOF {
+		fmt.Println(err)
+	}
+}
+
+func IoLimitedReader(r *io.LimitedReader) {
+	var buf [4096]byte
+	_, err := r.Read(buf[:])
+	if err == io.EOF {
+		fmt.Println(err)
+	}
+}
+
+func IoSectionReader(r *io.SectionReader) {
+	var buf [4096]byte
+	_, err := r.Read(buf[:])
+	if err == io.EOF {
+		fmt.Println(err)
+	}
+	_, err = r.ReadAt(buf[:], 0)
+	if err == io.EOF {
+		fmt.Println(err)
+	}
+}
+
+func ElfOpen() {
+	_, err := elf.Open("file")
+	if err == io.EOF {
+		fmt.Println(err)
+	}
+}
+
+func ElfNewFile(r io.ReaderAt) {
+	_, err := elf.NewFile(r)
+	if err == io.EOF {
 		fmt.Println(err)
 	}
 }


### PR DESCRIPTION
debug/elf.Open and debug/elf.NewFile uses io.ReaderAt and return its error verbatim.

Added function and methods from io package are documented to return EOF.