### PR TITLE
Allow bare errors from golang.org/x/sys/unix

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -3,6 +3,7 @@ package errorlint
 import (
 	"fmt"
 	"go/ast"
+	"strings"
 )
 
 var allowedErrors = []struct {
@@ -71,7 +72,21 @@ var allowedErrors = []struct {
 	{err: "io.EOF", fun: "(*strings.Reader).ReadRune"},
 }
 
+var allowedErrorWildcards = []struct {
+	err string
+	fun string
+}{
+	// golang.org/x/sys/unix
+	{err: "golang.org/x/sys/unix.E", fun: "golang.org/x/sys/unix."},
+}
+
 func isAllowedErrAndFunc(err, fun string) bool {
+	for _, allow := range allowedErrorWildcards {
+		if strings.HasPrefix(fun, allow.fun) && strings.HasPrefix(err, allow.err) {
+			return true
+		}
+	}
+
 	for _, allow := range allowedErrors {
 		if allow.fun == fun && allow.err == err {
 			return true

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -10,6 +10,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func CompareErrIndirect(r io.Reader) {
@@ -213,5 +216,14 @@ func TarHeader(r io.Reader) {
 			break
 		}
 		_ = header
+	}
+}
+
+func CompareUnixErrors() {
+	if err := unix.Rmdir("somepath"); err != unix.ENOENT {
+		fmt.Println(err)
+	}
+	if err := unix.Kill(1, syscall.SIGKILL); err != unix.EPERM {
+		fmt.Println(err)
 	}
 }


### PR DESCRIPTION
All functions in golang.org/x/sys/unix always return raw errno values,
which can be compared directly.
    
There are about 100-130 errors, and about 350 functions in unix package.
Listing them separately is hardly an option, so let's ignore all unix.E*
errors that come from all functions in unix package.
    
This functionality is made possible thanks to commit cd16050dfa0abd.
    
Add a small test case (we can't really add the whole x/sys/unix under
testdata, so use a stub implementation).
    
Fixes: https://github.com/polyfloyd/go-errorlint/issues/10