### PR TITLE
fix: add missing testdata

### DIFF
--- a/errorlint/testdata/src/golang.org/x/sys/unix/stubs.go
+++ b/errorlint/testdata/src/golang.org/x/sys/unix/stubs.go
@@ -1,0 +1,16 @@
+package unix
+
+import "syscall"
+
+const (
+	EPERM  = syscall.Errno(0x1)
+	ENOENT = syscall.Errno(0x2)
+)
+
+func Rmdir(string) error {
+	return ENOENT
+}
+
+func Kill(int, syscall.Signal) error {
+	return EPERM
+}


### PR DESCRIPTION
Commit 41edee20b684e61 forgot to add golang.org/x/sys/unix stub. Whoops.

Reported by @triarius in https://github.com/polyfloyd/go-errorlint/pull/51#issuecomment-1662145924