### PR TITLE
ci: do run Go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: go build
       run: go build -v
     - name: go test
-      run: go test -test.v -race -cover
+      run: go test -test.v -race -cover ./...
 
   conventional-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently, what happens in GHA CI now is:

> go test -test.v -race -cover
> shell: /usr/bin/bash -e {0}
> ?   	github.com/polyfloyd/go-errorlint	[no test files]

Fix this.

Note that this is why we missed an issue with #47 (the fix is in #52). Without the fix in #52 merged, this PR should make CI fail.