### PR TITLE
Add context errors as allowed direct comparisons

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -71,6 +71,9 @@ var allowedErrors = []struct {
 	{err: "io.EOF", fun: "(*strings.Reader).ReadAt"},
 	{err: "io.EOF", fun: "(*strings.Reader).ReadByte"},
 	{err: "io.EOF", fun: "(*strings.Reader).ReadRune"},
+	// pkg/context
+	{err: "context.DeadlineExceeded", fun: "(context.Context).Err"},
+	{err: "context.Canceled", fun: "(context.Context).Err"},
 }
 
 var allowedErrorWildcards = []struct {

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -3,6 +3,7 @@ package testdata
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"database/sql"
 	"debug/elf"
 	"errors"
@@ -226,4 +227,14 @@ func CompareUnixErrors() {
 	if err := unix.Kill(1, syscall.SIGKILL); err != unix.EPERM {
 		fmt.Println(err)
 	}
+}
+
+func ContextErr(ctx context.Context) error {
+	if err := ctx.Err(); err == context.DeadlineExceeded {
+		return err
+	}
+	if err := ctx.Err(); err == context.Canceled {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
The `DeadlineExceeded` and `Canceled` errors from the `context` package can be checked directly. This change adds those errors to the allow list + tests.