### PR TITLE
fix: init functions and AllowPair fields

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -8,101 +8,101 @@ import (
 )
 
 type AllowPair struct {
-	err string
-	fun string
+	Err string
+	Fun string
 }
 
 var allowedErrors = []AllowPair{
 	// pkg/archive/tar
-	{err: "io.EOF", fun: "(*archive/tar.Reader).Next"},
-	{err: "io.EOF", fun: "(*archive/tar.Reader).Read"},
+	{Err: "io.EOF", Fun: "(*archive/tar.Reader).Next"},
+	{Err: "io.EOF", Fun: "(*archive/tar.Reader).Read"},
 	// pkg/bufio
-	{err: "io.EOF", fun: "(*bufio.Reader).Discard"},
-	{err: "io.EOF", fun: "(*bufio.Reader).Peek"},
-	{err: "io.EOF", fun: "(*bufio.Reader).Read"},
-	{err: "io.EOF", fun: "(*bufio.Reader).ReadByte"},
-	{err: "io.EOF", fun: "(*bufio.Reader).ReadBytes"},
-	{err: "io.EOF", fun: "(*bufio.Reader).ReadLine"},
-	{err: "io.EOF", fun: "(*bufio.Reader).ReadSlice"},
-	{err: "io.EOF", fun: "(*bufio.Reader).ReadString"},
-	{err: "io.EOF", fun: "(*bufio.Scanner).Scan"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).Discard"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).Peek"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).Read"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadByte"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadBytes"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadLine"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadSlice"},
+	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadString"},
+	{Err: "io.EOF", Fun: "(*bufio.Scanner).Scan"},
 	// pkg/bytes
-	{err: "io.EOF", fun: "(*bytes.Buffer).Read"},
-	{err: "io.EOF", fun: "(*bytes.Buffer).ReadByte"},
-	{err: "io.EOF", fun: "(*bytes.Buffer).ReadBytes"},
-	{err: "io.EOF", fun: "(*bytes.Buffer).ReadRune"},
-	{err: "io.EOF", fun: "(*bytes.Buffer).ReadString"},
-	{err: "io.EOF", fun: "(*bytes.Reader).Read"},
-	{err: "io.EOF", fun: "(*bytes.Reader).ReadAt"},
-	{err: "io.EOF", fun: "(*bytes.Reader).ReadByte"},
-	{err: "io.EOF", fun: "(*bytes.Reader).ReadRune"},
-	{err: "io.EOF", fun: "(*bytes.Reader).ReadString"},
+	{Err: "io.EOF", Fun: "(*bytes.Buffer).Read"},
+	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadByte"},
+	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadBytes"},
+	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadRune"},
+	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadString"},
+	{Err: "io.EOF", Fun: "(*bytes.Reader).Read"},
+	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadAt"},
+	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadByte"},
+	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadRune"},
+	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadString"},
 	// pkg/database/sql
-	{err: "database/sql.ErrNoRows", fun: "(*database/sql.Row).Scan"},
+	{Err: "database/sql.ErrNoRows", Fun: "(*database/sql.Row).Scan"},
 	// pkg/debug/elf
-	{err: "io.EOF", fun: "debug/elf.Open"},
-	{err: "io.EOF", fun: "debug/elf.NewFile"},
+	{Err: "io.EOF", Fun: "debug/elf.Open"},
+	{Err: "io.EOF", Fun: "debug/elf.NewFile"},
 	// pkg/io
-	{err: "io.EOF", fun: "(io.ReadCloser).Read"},
-	{err: "io.EOF", fun: "(io.Reader).Read"},
-	{err: "io.EOF", fun: "(io.ReaderAt).ReadAt"},
-	{err: "io.EOF", fun: "(*io.LimitedReader).Read"},
-	{err: "io.EOF", fun: "(*io.SectionReader).Read"},
-	{err: "io.EOF", fun: "(*io.SectionReader).ReadAt"},
-	{err: "io.ErrClosedPipe", fun: "(*io.PipeWriter).Write"},
-	{err: "io.ErrShortBuffer", fun: "io.ReadAtLeast"},
-	{err: "io.ErrUnexpectedEOF", fun: "io.ReadAtLeast"},
-	{err: "io.EOF", fun: "io.ReadFull"},
-	{err: "io.ErrUnexpectedEOF", fun: "io.ReadFull"},
+	{Err: "io.EOF", Fun: "(io.ReadCloser).Read"},
+	{Err: "io.EOF", Fun: "(io.Reader).Read"},
+	{Err: "io.EOF", Fun: "(io.ReaderAt).ReadAt"},
+	{Err: "io.EOF", Fun: "(*io.LimitedReader).Read"},
+	{Err: "io.EOF", Fun: "(*io.SectionReader).Read"},
+	{Err: "io.EOF", Fun: "(*io.SectionReader).ReadAt"},
+	{Err: "io.ErrClosedPipe", Fun: "(*io.PipeWriter).Write"},
+	{Err: "io.ErrShortBuffer", Fun: "io.ReadAtLeast"},
+	{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadAtLeast"},
+	{Err: "io.EOF", Fun: "io.ReadFull"},
+	{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadFull"},
 	// pkg/net/http
-	{err: "net/http.ErrServerClosed", fun: "(*net/http.Server).ListenAndServe"},
-	{err: "net/http.ErrServerClosed", fun: "(*net/http.Server).ListenAndServeTLS"},
-	{err: "net/http.ErrServerClosed", fun: "(*net/http.Server).Serve"},
-	{err: "net/http.ErrServerClosed", fun: "(*net/http.Server).ServeTLS"},
-	{err: "net/http.ErrServerClosed", fun: "net/http.ListenAndServe"},
-	{err: "net/http.ErrServerClosed", fun: "net/http.ListenAndServeTLS"},
-	{err: "net/http.ErrServerClosed", fun: "net/http.Serve"},
-	{err: "net/http.ErrServerClosed", fun: "net/http.ServeTLS"},
+	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServe"},
+	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServeTLS"},
+	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).Serve"},
+	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ServeTLS"},
+	{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServe"},
+	{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServeTLS"},
+	{Err: "net/http.ErrServerClosed", Fun: "net/http.Serve"},
+	{Err: "net/http.ErrServerClosed", Fun: "net/http.ServeTLS"},
 	// pkg/os
-	{err: "io.EOF", fun: "(*os.File).Read"},
-	{err: "io.EOF", fun: "(*os.File).ReadAt"},
-	{err: "io.EOF", fun: "(*os.File).ReadDir"},
-	{err: "io.EOF", fun: "(*os.File).Readdir"},
-	{err: "io.EOF", fun: "(*os.File).Readdirnames"},
+	{Err: "io.EOF", Fun: "(*os.File).Read"},
+	{Err: "io.EOF", Fun: "(*os.File).ReadAt"},
+	{Err: "io.EOF", Fun: "(*os.File).ReadDir"},
+	{Err: "io.EOF", Fun: "(*os.File).Readdir"},
+	{Err: "io.EOF", Fun: "(*os.File).Readdirnames"},
 	// pkg/strings
-	{err: "io.EOF", fun: "(*strings.Reader).Read"},
-	{err: "io.EOF", fun: "(*strings.Reader).ReadAt"},
-	{err: "io.EOF", fun: "(*strings.Reader).ReadByte"},
-	{err: "io.EOF", fun: "(*strings.Reader).ReadRune"},
+	{Err: "io.EOF", Fun: "(*strings.Reader).Read"},
+	{Err: "io.EOF", Fun: "(*strings.Reader).ReadAt"},
+	{Err: "io.EOF", Fun: "(*strings.Reader).ReadByte"},
+	{Err: "io.EOF", Fun: "(*strings.Reader).ReadRune"},
 	// pkg/context
-	{err: "context.DeadlineExceeded", fun: "(context.Context).Err"},
-	{err: "context.Canceled", fun: "(context.Context).Err"},
+	{Err: "context.DeadlineExceeded", Fun: "(context.Context).Err"},
+	{Err: "context.Canceled", Fun: "(context.Context).Err"},
 	// pkg/encoding/json
-	{err: "io.EOF", fun: "(*encoding/json.Decoder).Decode"},
+	{Err: "io.EOF", Fun: "(*encoding/json.Decoder).Decode"},
 	// pkg/encoding/csv
-	{err: "io.EOF", fun: "(*encoding/csv.Reader).Read"},
+	{Err: "io.EOF", Fun: "(*encoding/csv.Reader).Read"},
 	// pkg/mime/multipart
-	{err: "io.EOF", fun: "(*mime/multipart.Reader).NextPart"},
-	{err: "io.EOF", fun: "(*mime/multipart.Reader).NextRawPart"},
-	{err: "mime/multipart.ErrMessageTooLarge", fun: "(*mime/multipart.Reader).ReadForm"},
+	{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextPart"},
+	{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextRawPart"},
+	{Err: "mime/multipart.ErrMessageTooLarge", Fun: "(*mime/multipart.Reader).ReadForm"},
 }
 
 var allowedErrorsMap = make(map[string]map[string]struct{})
 
 func allowedMapAppend(ap []AllowPair) {
 	for _, pair := range ap {
-		if _, ok := allowedErrorsMap[pair.err]; !ok {
-			allowedErrorsMap[pair.err] = make(map[string]struct{})
+		if _, ok := allowedErrorsMap[pair.Err]; !ok {
+			allowedErrorsMap[pair.Err] = make(map[string]struct{})
 		}
-		allowedErrorsMap[pair.err][pair.fun] = struct{}{}
+		allowedErrorsMap[pair.Err][pair.Fun] = struct{}{}
 	}
 }
 
 var allowedErrorWildcards = []AllowPair{
 	// pkg/syscall
-	{err: "syscall.E", fun: "syscall."},
+	{Err: "syscall.E", Fun: "syscall."},
 	// golang.org/x/sys/unix
-	{err: "golang.org/x/sys/unix.E", fun: "golang.org/x/sys/unix."},
+	{Err: "golang.org/x/sys/unix.E", Fun: "golang.org/x/sys/unix."},
 }
 
 func allowedWildcardAppend(ap []AllowPair) {
@@ -117,7 +117,7 @@ func isAllowedErrAndFunc(err, fun string) bool {
 	}
 
 	for _, allow := range allowedErrorWildcards {
-		if strings.HasPrefix(fun, allow.fun) && strings.HasPrefix(err, allow.err) {
+		if strings.HasPrefix(fun, allow.Fun) && strings.HasPrefix(err, allow.Err) {
 			return true
 		}
 	}

--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -12,82 +12,84 @@ type AllowPair struct {
 	Fun string
 }
 
-var allowedErrors = []AllowPair{
-	// pkg/archive/tar
-	{Err: "io.EOF", Fun: "(*archive/tar.Reader).Next"},
-	{Err: "io.EOF", Fun: "(*archive/tar.Reader).Read"},
-	// pkg/bufio
-	{Err: "io.EOF", Fun: "(*bufio.Reader).Discard"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).Peek"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).Read"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadByte"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadBytes"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadLine"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadSlice"},
-	{Err: "io.EOF", Fun: "(*bufio.Reader).ReadString"},
-	{Err: "io.EOF", Fun: "(*bufio.Scanner).Scan"},
-	// pkg/bytes
-	{Err: "io.EOF", Fun: "(*bytes.Buffer).Read"},
-	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadByte"},
-	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadBytes"},
-	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadRune"},
-	{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadString"},
-	{Err: "io.EOF", Fun: "(*bytes.Reader).Read"},
-	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadAt"},
-	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadByte"},
-	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadRune"},
-	{Err: "io.EOF", Fun: "(*bytes.Reader).ReadString"},
-	// pkg/database/sql
-	{Err: "database/sql.ErrNoRows", Fun: "(*database/sql.Row).Scan"},
-	// pkg/debug/elf
-	{Err: "io.EOF", Fun: "debug/elf.Open"},
-	{Err: "io.EOF", Fun: "debug/elf.NewFile"},
-	// pkg/io
-	{Err: "io.EOF", Fun: "(io.ReadCloser).Read"},
-	{Err: "io.EOF", Fun: "(io.Reader).Read"},
-	{Err: "io.EOF", Fun: "(io.ReaderAt).ReadAt"},
-	{Err: "io.EOF", Fun: "(*io.LimitedReader).Read"},
-	{Err: "io.EOF", Fun: "(*io.SectionReader).Read"},
-	{Err: "io.EOF", Fun: "(*io.SectionReader).ReadAt"},
-	{Err: "io.ErrClosedPipe", Fun: "(*io.PipeWriter).Write"},
-	{Err: "io.ErrShortBuffer", Fun: "io.ReadAtLeast"},
-	{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadAtLeast"},
-	{Err: "io.EOF", Fun: "io.ReadFull"},
-	{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadFull"},
-	// pkg/net/http
-	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServe"},
-	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServeTLS"},
-	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).Serve"},
-	{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ServeTLS"},
-	{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServe"},
-	{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServeTLS"},
-	{Err: "net/http.ErrServerClosed", Fun: "net/http.Serve"},
-	{Err: "net/http.ErrServerClosed", Fun: "net/http.ServeTLS"},
-	// pkg/os
-	{Err: "io.EOF", Fun: "(*os.File).Read"},
-	{Err: "io.EOF", Fun: "(*os.File).ReadAt"},
-	{Err: "io.EOF", Fun: "(*os.File).ReadDir"},
-	{Err: "io.EOF", Fun: "(*os.File).Readdir"},
-	{Err: "io.EOF", Fun: "(*os.File).Readdirnames"},
-	// pkg/strings
-	{Err: "io.EOF", Fun: "(*strings.Reader).Read"},
-	{Err: "io.EOF", Fun: "(*strings.Reader).ReadAt"},
-	{Err: "io.EOF", Fun: "(*strings.Reader).ReadByte"},
-	{Err: "io.EOF", Fun: "(*strings.Reader).ReadRune"},
-	// pkg/context
-	{Err: "context.DeadlineExceeded", Fun: "(context.Context).Err"},
-	{Err: "context.Canceled", Fun: "(context.Context).Err"},
-	// pkg/encoding/json
-	{Err: "io.EOF", Fun: "(*encoding/json.Decoder).Decode"},
-	// pkg/encoding/csv
-	{Err: "io.EOF", Fun: "(*encoding/csv.Reader).Read"},
-	// pkg/mime/multipart
-	{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextPart"},
-	{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextRawPart"},
-	{Err: "mime/multipart.ErrMessageTooLarge", Fun: "(*mime/multipart.Reader).ReadForm"},
-}
-
 var allowedErrorsMap = make(map[string]map[string]struct{})
+
+func setDefaultAllowedErrors() {
+	allowedMapAppend([]AllowPair{
+		// pkg/archive/tar
+		{Err: "io.EOF", Fun: "(*archive/tar.Reader).Next"},
+		{Err: "io.EOF", Fun: "(*archive/tar.Reader).Read"},
+		// pkg/bufio
+		{Err: "io.EOF", Fun: "(*bufio.Reader).Discard"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).Peek"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).Read"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).ReadByte"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).ReadBytes"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).ReadLine"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).ReadSlice"},
+		{Err: "io.EOF", Fun: "(*bufio.Reader).ReadString"},
+		{Err: "io.EOF", Fun: "(*bufio.Scanner).Scan"},
+		// pkg/bytes
+		{Err: "io.EOF", Fun: "(*bytes.Buffer).Read"},
+		{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadByte"},
+		{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadBytes"},
+		{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadRune"},
+		{Err: "io.EOF", Fun: "(*bytes.Buffer).ReadString"},
+		{Err: "io.EOF", Fun: "(*bytes.Reader).Read"},
+		{Err: "io.EOF", Fun: "(*bytes.Reader).ReadAt"},
+		{Err: "io.EOF", Fun: "(*bytes.Reader).ReadByte"},
+		{Err: "io.EOF", Fun: "(*bytes.Reader).ReadRune"},
+		{Err: "io.EOF", Fun: "(*bytes.Reader).ReadString"},
+		// pkg/database/sql
+		{Err: "database/sql.ErrNoRows", Fun: "(*database/sql.Row).Scan"},
+		// pkg/debug/elf
+		{Err: "io.EOF", Fun: "debug/elf.Open"},
+		{Err: "io.EOF", Fun: "debug/elf.NewFile"},
+		// pkg/io
+		{Err: "io.EOF", Fun: "(io.ReadCloser).Read"},
+		{Err: "io.EOF", Fun: "(io.Reader).Read"},
+		{Err: "io.EOF", Fun: "(io.ReaderAt).ReadAt"},
+		{Err: "io.EOF", Fun: "(*io.LimitedReader).Read"},
+		{Err: "io.EOF", Fun: "(*io.SectionReader).Read"},
+		{Err: "io.EOF", Fun: "(*io.SectionReader).ReadAt"},
+		{Err: "io.ErrClosedPipe", Fun: "(*io.PipeWriter).Write"},
+		{Err: "io.ErrShortBuffer", Fun: "io.ReadAtLeast"},
+		{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadAtLeast"},
+		{Err: "io.EOF", Fun: "io.ReadFull"},
+		{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadFull"},
+		// pkg/net/http
+		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServe"},
+		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServeTLS"},
+		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).Serve"},
+		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ServeTLS"},
+		{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServe"},
+		{Err: "net/http.ErrServerClosed", Fun: "net/http.ListenAndServeTLS"},
+		{Err: "net/http.ErrServerClosed", Fun: "net/http.Serve"},
+		{Err: "net/http.ErrServerClosed", Fun: "net/http.ServeTLS"},
+		// pkg/os
+		{Err: "io.EOF", Fun: "(*os.File).Read"},
+		{Err: "io.EOF", Fun: "(*os.File).ReadAt"},
+		{Err: "io.EOF", Fun: "(*os.File).ReadDir"},
+		{Err: "io.EOF", Fun: "(*os.File).Readdir"},
+		{Err: "io.EOF", Fun: "(*os.File).Readdirnames"},
+		// pkg/strings
+		{Err: "io.EOF", Fun: "(*strings.Reader).Read"},
+		{Err: "io.EOF", Fun: "(*strings.Reader).ReadAt"},
+		{Err: "io.EOF", Fun: "(*strings.Reader).ReadByte"},
+		{Err: "io.EOF", Fun: "(*strings.Reader).ReadRune"},
+		// pkg/context
+		{Err: "context.DeadlineExceeded", Fun: "(context.Context).Err"},
+		{Err: "context.Canceled", Fun: "(context.Context).Err"},
+		// pkg/encoding/json
+		{Err: "io.EOF", Fun: "(*encoding/json.Decoder).Decode"},
+		// pkg/encoding/csv
+		{Err: "io.EOF", Fun: "(*encoding/csv.Reader).Read"},
+		// pkg/mime/multipart
+		{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextPart"},
+		{Err: "io.EOF", Fun: "(*mime/multipart.Reader).NextRawPart"},
+		{Err: "mime/multipart.ErrMessageTooLarge", Fun: "(*mime/multipart.Reader).ReadForm"},
+	})
+}
 
 func allowedMapAppend(ap []AllowPair) {
 	for _, pair := range ap {

--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -98,10 +98,6 @@ func allowedMapAppend(ap []AllowPair) {
 	}
 }
 
-func init() {
-	allowedMapAppend(allowedErrors)
-}
-
 var allowedErrorWildcards = []AllowPair{
 	// pkg/syscall
 	{err: "syscall.E", fun: "syscall."},

--- a/errorlint/allowed_test.go
+++ b/errorlint/allowed_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func Test_isAllowedErrAndFunc(t *testing.T) {
+	allowedMapAppend(allowedErrors)
+
 	testCases := []struct {
 		desc   string
 		fun    string
@@ -31,6 +33,7 @@ func Test_isAllowedErrAndFunc(t *testing.T) {
 		},
 		// {desc: "fail test", expect: true},
 	}
+
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
 			result := isAllowedErrAndFunc(tt.err, tt.fun)

--- a/errorlint/allowed_test.go
+++ b/errorlint/allowed_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Test_isAllowedErrAndFunc(t *testing.T) {
-	allowedMapAppend(allowedErrors)
+	setDefaultAllowedErrors()
 
 	testCases := []struct {
 		desc   string

--- a/errorlint/analysis.go
+++ b/errorlint/analysis.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	lints := []analysis.Diagnostic{}
+	var lints []analysis.Diagnostic
 	extInfo := newTypesInfoExt(pass)
 	if checkComparison {
 		l := LintErrorComparisons(extInfo)

--- a/errorlint/analysis.go
+++ b/errorlint/analysis.go
@@ -13,6 +13,9 @@ func NewAnalyzer(opts ...Option) *analysis.Analyzer {
 	for _, o := range opts {
 		o()
 	}
+
+	allowedMapAppend(allowedErrors)
+
 	return &analysis.Analyzer{
 		Name:  "errorlint",
 		Doc:   "Source code linter for Go software that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.",

--- a/errorlint/analysis.go
+++ b/errorlint/analysis.go
@@ -13,7 +13,7 @@ func NewAnalyzer(opts ...Option) *analysis.Analyzer {
 		o()
 	}
 
-	allowedMapAppend(allowedErrors)
+	setDefaultAllowedErrors()
 
 	a := &analysis.Analyzer{
 		Name: "errorlint",

--- a/errorlint/analysis.go
+++ b/errorlint/analysis.go
@@ -1,7 +1,6 @@
 package errorlint
 
 import (
-	"flag"
 	"go/ast"
 	"go/types"
 	"sort"
@@ -16,28 +15,26 @@ func NewAnalyzer(opts ...Option) *analysis.Analyzer {
 
 	allowedMapAppend(allowedErrors)
 
-	return &analysis.Analyzer{
-		Name:  "errorlint",
-		Doc:   "Source code linter for Go software that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.",
-		Run:   run,
-		Flags: flagSet,
+	a := &analysis.Analyzer{
+		Name: "errorlint",
+		Doc:  "Source code linter for Go software that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.",
+		Run:  run,
 	}
+
+	a.Flags.BoolVar(&checkComparison, "comparison", true, "Check for plain error comparisons")
+	a.Flags.BoolVar(&checkAsserts, "asserts", true, "Check for plain type assertions and type switches")
+	a.Flags.BoolVar(&checkErrorf, "errorf", false, "Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats")
+	a.Flags.BoolVar(&checkErrorfMulti, "errorf-multi", true, "Permit more than 1 %w verb, valid per Go 1.20 (Requires -errorf=true)")
+
+	return a
 }
 
 var (
-	flagSet          flag.FlagSet
 	checkComparison  bool
 	checkAsserts     bool
 	checkErrorf      bool
 	checkErrorfMulti bool
 )
-
-func init() {
-	flagSet.BoolVar(&checkComparison, "comparison", true, "Check for plain error comparisons")
-	flagSet.BoolVar(&checkAsserts, "asserts", true, "Check for plain type assertions and type switches")
-	flagSet.BoolVar(&checkErrorf, "errorf", false, "Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats")
-	flagSet.BoolVar(&checkErrorfMulti, "errorf-multi", true, "Permit more than 1 %w verb, valid per Go 1.20 (Requires -errorf=true)")
-}
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	var lints []analysis.Diagnostic

--- a/errorlint/analysis_test.go
+++ b/errorlint/analysis_test.go
@@ -39,35 +39,6 @@ func TestAllowedComparisons(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), analyzer, "allowed")
 }
 
-func TestOptions(t *testing.T) {
-	testCases := []struct {
-		desc    string
-		opt     Option
-		pattern string
-	}{
-		{
-			desc: "WithAllowedErrors",
-			opt: WithAllowedErrors([]AllowPair{
-				{err: "io.EOF", fun: "example.com/pkg.Read"},
-			}),
-			pattern: "options/withAllowedErrors",
-		},
-		{
-			desc: "WithAllowedWildcard",
-			opt: WithAllowedWildcard([]AllowPair{
-				{err: "example.com/pkg.ErrMagic", fun: "example.com/pkg.Magic"},
-			}),
-			pattern: "options/withAllowedWildcard",
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.desc, func(t *testing.T) {
-			analyzer := NewAnalyzer(tt.opt)
-			analysistest.Run(t, analysistest.TestData(), analyzer, tt.pattern)
-		})
-	}
-}
-
 func TestIssueRegressions(t *testing.T) {
 	analyzer := NewAnalyzer()
 	analysistest.Run(t, analysistest.TestData(), analyzer, "issues")

--- a/errorlint/lint.go
+++ b/errorlint/lint.go
@@ -20,7 +20,8 @@ func (l ByPosition) Less(i, j int) bool {
 }
 
 func LintFmtErrorfCalls(fset *token.FileSet, info types.Info, multipleWraps bool) []analysis.Diagnostic {
-	lints := []analysis.Diagnostic{}
+	var lints []analysis.Diagnostic
+
 	for expr, t := range info.Types {
 		// Search for error expressions that are the result of fmt.Errorf
 		// invocations.
@@ -159,7 +160,7 @@ func isFmtErrorfCallExpr(info types.Info, expr ast.Expr) (*ast.CallExpr, bool) {
 }
 
 func LintErrorComparisons(info *TypesInfoExt) []analysis.Diagnostic {
-	lints := []analysis.Diagnostic{}
+	var lints []analysis.Diagnostic
 
 	for expr := range info.TypesInfo.Types {
 		// Find == and != operations.
@@ -289,7 +290,7 @@ func switchComparesNonNil(switchStmt *ast.SwitchStmt) bool {
 }
 
 func LintErrorTypeAssertions(fset *token.FileSet, info *TypesInfoExt) []analysis.Diagnostic {
-	lints := []analysis.Diagnostic{}
+	var lints []analysis.Diagnostic
 
 	for expr := range info.TypesInfo.Types {
 		// Find type assertions.

--- a/errorlint/options_test.go
+++ b/errorlint/options_test.go
@@ -1,0 +1,38 @@
+package errorlint_test
+
+import (
+	"testing"
+
+	"github.com/polyfloyd/go-errorlint/errorlint"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestOption(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		opt     errorlint.Option
+		pattern string
+	}{
+		{
+			desc: "WithAllowedErrors",
+			opt: errorlint.WithAllowedErrors([]errorlint.AllowPair{
+				{Err: "io.EOF", Fun: "example.com/pkg.Read"},
+			}),
+			pattern: "options/withAllowedErrors",
+		},
+		{
+			desc: "WithAllowedWildcard",
+			opt: errorlint.WithAllowedWildcard([]errorlint.AllowPair{
+				{Err: "example.com/pkg.ErrMagic", Fun: "example.com/pkg.Magic"},
+			}),
+			pattern: "options/withAllowedWildcard",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			analyzer := errorlint.NewAnalyzer(tt.opt)
+			analysistest.Run(t, analysistest.TestData(), analyzer, tt.pattern)
+		})
+	}
+}

--- a/errorlint/testdata/src/issues/github-21.go
+++ b/errorlint/testdata/src/issues/github-21.go
@@ -8,9 +8,9 @@ import (
 )
 
 func Test1() error {
-	return fmt.Errorf("%[1]v %[1]v: %w", "value", errors.New("abc")) // want "non-wrapping format verb for fmt.Errorf. Use `%w` to format errors"
+	return fmt.Errorf("%[1]v %[1]v: %w", "value", errors.New("abc"))
 }
 
 func Test2() error {
-	return fmt.Errorf("%[1]v: %[1]w", errors.New("abc")) // want "non-wrapping format verb for fmt.Errorf. Use `%w` to format errors"
+	return fmt.Errorf("%[1]v: %[1]w", errors.New("abc"))
 }


### PR DESCRIPTION
golangci-lint uses `go-errorlint` as a lib, then `init` functions can be a problem because they are always called.

The PR removes the need to use `init` functions:
- to load `allowedErrorsMap`
- for the flags (this fixes a regression: issue #21 has been fixed with f57ae321623d3e45f7ca6010c6c11e2dbf53e849 but aed56418cd3705e4635c1be0c8951462bfeafb48 inverts the expected behavior).

The new signature of `NewAnalyzer` allows to set use options but the fields of `AllowPair` are not exposed, so it's impossible to use `WithAllowedErrors` or `WithAllowedWildcard`.
The PR exposes the fields `err` and `fun` of the structure `AllowPair`.

Related to #69