### PR TITLE
feat: add exception for mime.ErrInvalidMediaParameter

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -57,6 +57,8 @@ func setDefaultAllowedErrors() {
 		{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadAtLeast"},
 		{Err: "io.EOF", Fun: "io.ReadFull"},
 		{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadFull"},
+		// pkg/mime
+		{Err: "mime.ErrInvalidMediaParameter", Fun: "mime.ParseMediaType"},
 		// pkg/net/http
 		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServe"},
 		{Err: "net/http.ErrServerClosed", Fun: "(*net/http.Server).ListenAndServeTLS"},

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -279,6 +280,13 @@ func MIMEMultipartReader(r io.Reader, boundary string, raw bool) {
 func MIMEMultipartReadFrom(r io.Reader, boundary string, maxMemory int64) {
 	_, err := multipart.NewReader(r, boundary).ReadForm(maxMemory)
 	if err == multipart.ErrMessageTooLarge {
+		fmt.Println(err)
+	}
+}
+
+func MimeParseMediaType(contentType string) {
+	_, _, err := mime.ParseMediaType(contentType)
+	if err == mime.ErrInvalidMediaParameter {
 		fmt.Println(err)
 	}
 }


### PR DESCRIPTION
It is documented ([1]) that `mime.ParseMediaType` can return `mime.ErrInvalidMediaParameter` error, so it's not a bug to perform a direct comparison.

[1]: https://pkg.go.dev/mime#ParseMediaType
