### PR TITLE
ci: cz: only check commits in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       run: go test -test.v -race -cover ./...
 
   conventional-commits:
+    if: github.event_name == 'pull_request' # Only check PRs.
     runs-on: ubuntu-latest
 
     steps:
@@ -35,5 +36,4 @@ jobs:
       with:
         fetch-depth: 0
     - run: pip3 install -U Commitizen
-      # The commit hash here is that of the commit where we started using conventional commits.
-    - run: cz check --rev-range deebab92..HEAD
+    - run: cz check --rev-range origin/${{ github.base_ref }}..HEAD

--- a/errorlint/allowed_test.go
+++ b/errorlint/allowed_test.go
@@ -45,7 +45,7 @@ func Test_isAllowedErrAndFunc(t *testing.T) {
 }
 
 func Benchmark_isAllowedErrAndFunc(b *testing.B) {
-	var benchCases = []struct {
+	benchCases := []struct {
 		desc string
 		err  string
 		fun  string


### PR DESCRIPTION
Once something is merged, it does not make sense (and it's too late) to check it.

So, limit the check to commits in a given PR.

This fixes this repo CI (broken by merging #77).