### PR TITLE
Add exception for encoding/json.decoder.Token

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -84,6 +84,7 @@ func setDefaultAllowedErrors() {
 		{Err: "context.Canceled", Fun: "(context.Context).Err"},
 		// pkg/encoding/json
 		{Err: "io.EOF", Fun: "(*encoding/json.Decoder).Decode"},
+		{Err: "io.EOF", Fun: "(*encoding/json.Decoder).Token"},
 		// pkg/encoding/csv
 		{Err: "io.EOF", Fun: "(*encoding/csv.Reader).Read"},
 		// pkg/mime/multipart

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -251,11 +251,16 @@ func ContextErr(ctx context.Context) error {
 	return nil
 }
 
-func JSONReader(r io.Reader) {
-	err := json.NewDecoder(r).Decode(nil)
+func JSONReader(dec *json.Decoder) (err error) {
+	_, err = dec.Token()
 	if err == io.EOF {
-		fmt.Println(err)
+		return
 	}
+	err = dec.Decode(nil)
+	if err == io.EOF {
+		return
+	}
+	return
 }
 
 func CSVReader(r io.Reader) {


### PR DESCRIPTION
As noted in https://pkg.go.dev/encoding/json#Decoder.Token, it can return io.EOF.

Add a test case.