### PR TITLE
feat: ignore io.EOF from io.ReadAtLeast

### DIFF
--- a/errorlint/allowed.go
+++ b/errorlint/allowed.go
@@ -53,6 +53,7 @@ func setDefaultAllowedErrors() {
 		{Err: "io.EOF", Fun: "(*io.SectionReader).Read"},
 		{Err: "io.EOF", Fun: "(*io.SectionReader).ReadAt"},
 		{Err: "io.ErrClosedPipe", Fun: "(*io.PipeWriter).Write"},
+		{Err: "io.EOF", Fun: "io.ReadAtLeast"},
 		{Err: "io.ErrShortBuffer", Fun: "io.ReadAtLeast"},
 		{Err: "io.ErrUnexpectedEOF", Fun: "io.ReadAtLeast"},
 		{Err: "io.EOF", Fun: "io.ReadFull"},

--- a/errorlint/testdata/src/allowed/allowed.go
+++ b/errorlint/testdata/src/allowed/allowed.go
@@ -106,15 +106,13 @@ func IoPipeWriterWrite(w *io.PipeWriter) {
 	}
 }
 
-func IoReadAtLeast(r io.Reader) {
+func IoReadAtLeast(r io.Reader) error {
 	var buf [4096]byte
 	_, err := io.ReadAtLeast(r, buf[:], 8192)
-	if err == io.ErrShortBuffer {
-		fmt.Println(err)
+	if err == io.ErrShortBuffer || err == io.ErrUnexpectedEOF || err == io.EOF {
+		return err
 	}
-	if err == io.ErrUnexpectedEOF {
-		fmt.Println(err)
-	}
+	return nil
 }
 
 func IoReadFull(r io.Reader) {


### PR DESCRIPTION
See https://pkg.go.dev/io#ReadAtLeast