### PR TITLE
fix: golang.org/x/tools requires go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
       with:
         go-version: stable
 
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+    - name: Check go mod
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod
+        git diff --exit-code go.sum
     - name: go build
       run: go build -v
     - name: go test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/polyfloyd/go-errorlint
 
-go 1.20
+go 1.22.0
 
 require golang.org/x/tools v0.27.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=


### PR DESCRIPTION
The PR bumps the `go` version in `go.mod` to `1.22` because the package `golang.org/x/tools` requires [Go 1.22](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.27.0:go.mod;l=3).

This was discovered by simply building `go-errorlint` locally.
```sh
❯ git clone https://github.com/polyfloyd/go-errorlint.git
Cloning into 'go-errorlint'...
remote: Enumerating objects: 787, done.
remote: Counting objects: 100% (123/123), done.
remote: Compressing objects: 100% (79/79), done.
remote: Total 787 (delta 75), reused 52 (delta 39), pack-reused 664 (from 1)
Receiving objects: 100% (787/787), 122.00 KiB | 1.56 MiB/s, done.
Resolving deltas: 100% (440/440), done.
❯ cd go-errorlint
❯ go version
go version go1.23.3 darwin/arm64
❯ go build -v
go: updates to go.mod needed; to update it:
        go mod tidy
```