### PR TITLE
docs: simplify documentation for errorlint analyzer

### DIFF
--- a/errorlint/analysis.go
+++ b/errorlint/analysis.go
@@ -17,7 +17,7 @@ func NewAnalyzer(opts ...Option) *analysis.Analyzer {
 
 	a := &analysis.Analyzer{
 		Name: "errorlint",
-		Doc:  "Source code linter for Go software that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.",
+		Doc:  "Linter for error wrapping issues.",
 		Run:  run,
 	}
 


### PR DESCRIPTION
The PR proposes to simplify the analyzer documentation string. Go 1.13 was released a long time ago, so there is no need to mention it. "Go software" is obvious because "golang.org/x/tools/go/analysis" can only be used for Go linters.


Now, the description is short and concise:
```sh
❯ go run main.go
errorlint: Linter for error wrapping issues.
```