### PR TITLE
feat: Add automatic error comparison and type assertion fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ go-errorlint -fix ./...
 ```
 
 The tool can automatically fix:
+
+> [!CAUTION]
+> These fixes are still under development and the behavior is not yet stable.
+> It is possible that it will make mistakes and cause more harm than good.
+> Use with caution.
+
 1. Non-wrapping format verb for fmt.Errorf (changing `%v` to `%w`)
 2. Direct error comparisons (replacing `err == ErrFoo` with `errors.Is(err, ErrFoo)`)
 3. Type assertions on errors (replacing `err.(*MyError)` with `errors.As` usage)
@@ -82,6 +88,8 @@ Errors returned from standard library functions that explicitly document that
 an unwrapped error is returned are allowed by the linter. Notable cases are
 `io.EOF` and `sql.ErrNoRows`.
 
+You can pass `-fix` to have go-errorlint automatically fix these issues for you.
+
 **Caveats**:
 * Comparing the error returned from `(io.Reader).Read` to `io.EOF` without
   `errors.Is` is considered valid as this is
@@ -106,6 +114,8 @@ case *MyError:
 var me MyError
 ok := errors.As(err, &me)
 ```
+
+You can pass `-fix` to have go-errorlint automatically fix these issues for you.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ go-errorlint ./...
 ```
 If there are one or more results, the exit status is set to `1`.
 
+To automatically fix issues where possible, use the `-fix` flag:
+```
+go-errorlint -fix ./...
+```
+
+The tool can automatically fix:
+1. Non-wrapping format verb for fmt.Errorf (changing `%v` to `%w`)
+2. Direct error comparisons (replacing `err == ErrFoo` with `errors.Is(err, ErrFoo)`)
+3. Type assertions on errors (replacing `err.(*MyError)` with `errors.As` usage)
+
+Complex cases like switches on errors or type switches cannot be automatically fixed.
+
 
 ## Examples
 

--- a/errorlint/analysis_test.go
+++ b/errorlint/analysis_test.go
@@ -43,3 +43,13 @@ func TestIssueRegressions(t *testing.T) {
 	analyzer := NewAnalyzer()
 	analysistest.Run(t, analysistest.TestData(), analyzer, "issues")
 }
+
+func TestErrorComparisonFixes(t *testing.T) {
+	analyzer := NewAnalyzer()
+	analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), analyzer, "errorcompare")
+}
+
+func TestErrorTypeAssertionFixes(t *testing.T) {
+	analyzer := NewAnalyzer()
+	analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), analyzer, "errorassert")
+}

--- a/errorlint/lint.go
+++ b/errorlint/lint.go
@@ -475,14 +475,8 @@ func LintErrorTypeAssertions(fset *token.FileSet, info *TypesInfoExt) []analysis
 		targetType := exprToString(typeAssert.Type)
 		errExpr := exprToString(typeAssert.X)
 
-		// Check if the type is a pointer type,
-		isPointerType := strings.HasPrefix(targetType, "*")
-		// If it's not a pointer type, we'll need to create a variable of the same type
-		// but still need to pass its address to errors.As.
-		baseType := targetType
-		if isPointerType {
-			baseType = strings.TrimPrefix(targetType, "*")
-		}
+		// Check if the type is a pointer type
+		baseType, isPointerType := strings.CutPrefix(targetType, "*")
 
 		parent := info.NodeParent[typeAssert]
 

--- a/errorlint/lint.go
+++ b/errorlint/lint.go
@@ -1,11 +1,14 @@
 package errorlint
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/constant"
+	"go/printer"
 	"go/token"
 	"go/types"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -188,10 +191,46 @@ func LintErrorComparisons(info *TypesInfoExt) []analysis.Diagnostic {
 			continue
 		}
 
-		lints = append(lints, analysis.Diagnostic{
+		diagnostic := analysis.Diagnostic{
 			Message: fmt.Sprintf("comparing with %s will fail on wrapped errors. Use errors.Is to check for a specific error", binExpr.Op),
 			Pos:     binExpr.Pos(),
-		})
+		}
+
+		// Add suggested fix
+		var errVar, targetErr ast.Expr
+		// Identify which side is the error variable and which is the sentinel error
+		if isErrorType(info.TypesInfo, binExpr.X) && isErrorType(info.TypesInfo, binExpr.Y) {
+			// If both sides are errors, we'll use them as is
+			errVar = binExpr.X
+			targetErr = binExpr.Y
+		} else if isErrorType(info.TypesInfo, binExpr.X) {
+			errVar = binExpr.X
+			targetErr = binExpr.Y
+		} else {
+			errVar = binExpr.Y
+			targetErr = binExpr.X
+		}
+
+		negated := binExpr.Op == token.NEQ
+
+		// Build the suggested fix - preserve the original order of parameters
+		var replacement string
+		if negated {
+			replacement = fmt.Sprintf("!errors.Is(%s, %s)", exprToString(errVar), exprToString(targetErr))
+		} else {
+			replacement = fmt.Sprintf("errors.Is(%s, %s)", exprToString(errVar), exprToString(targetErr))
+		}
+
+		diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+			Message: "Use errors.Is() to compare errors",
+			TextEdits: []analysis.TextEdit{{
+				Pos:     binExpr.Pos(),
+				End:     binExpr.End(),
+				NewText: []byte(replacement),
+			}},
+		}}
+
+		lints = append(lints, diagnostic)
 	}
 
 	for scope := range info.TypesInfo.Scopes {
@@ -229,14 +268,119 @@ func LintErrorComparisons(info *TypesInfoExt) []analysis.Diagnostic {
 		}
 
 		if switchComparesNonNil(switchStmt) {
-			lints = append(lints, analysis.Diagnostic{
+			diagnostic := analysis.Diagnostic{
 				Message: "switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors",
 				Pos:     problematicCaseClause.Pos(),
-			})
+			}
+
+			// Create a simpler version of the fix for switch statements
+			// We'll transform: switch err { case ErrX: ... }
+			// To:             switch { case errors.Is(err, ErrX): ... }
+
+			// Create a new switch statement with an empty tag
+			newSwitchStmt := &ast.SwitchStmt{
+				Init: switchStmt.Init,
+				Tag:  nil, // Empty tag for the switch
+				Body: &ast.BlockStmt{
+					List: make([]ast.Stmt, len(switchStmt.Body.List)),
+				},
+			}
+
+			// Convert each case to use errors.Is
+			switchTagExpr := switchStmt.Tag // The error variable being checked
+			for i, stmt := range switchStmt.Body.List {
+				origCaseClause := stmt.(*ast.CaseClause)
+
+				// Create a new case clause
+				newCaseClause := &ast.CaseClause{
+					Body: origCaseClause.Body,
+				}
+
+				// If this is a default case (no expressions), keep it as-is
+				if len(origCaseClause.List) == 0 {
+					newCaseClause.List = nil // Default case
+				} else {
+					newCaseClause.List = make([]ast.Expr, 0, len(origCaseClause.List))
+
+					// Convert each case expression
+					for _, caseExpr := range origCaseClause.List {
+						if isNil(caseExpr) {
+							// Keep nil checks as is: case err == nil:
+							newCaseClause.List = append(newCaseClause.List,
+								&ast.BinaryExpr{
+									X:  switchTagExpr,
+									Op: token.EQL,
+									Y:  caseExpr,
+								})
+						} else {
+							// Replace err == ErrX with errors.Is(err, ErrX)
+							newCaseClause.List = append(newCaseClause.List,
+								&ast.CallExpr{
+									Fun: &ast.SelectorExpr{
+										X:   ast.NewIdent("errors"),
+										Sel: ast.NewIdent("Is"),
+									},
+									Args: []ast.Expr{switchTagExpr, caseExpr},
+								})
+						}
+					}
+				}
+
+				newSwitchStmt.Body.List[i] = newCaseClause
+			}
+
+			// Print the modified AST to get the fix text
+			var buf bytes.Buffer
+			printer.Fprint(&buf, token.NewFileSet(), newSwitchStmt)
+			fixText := buf.String()
+
+			diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+				Message: "Convert to errors.Is() for error comparisons",
+				TextEdits: []analysis.TextEdit{{
+					Pos:     switchStmt.Pos(),
+					End:     switchStmt.End(),
+					NewText: []byte(fixText),
+				}},
+			}}
+
+			lints = append(lints, diagnostic)
 		}
 	}
 
 	return lints
+}
+
+// exprToString converts an expression to its string representation
+func exprToString(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return exprToString(e.X) + "." + e.Sel.Name
+	case *ast.StarExpr:
+		return "*" + exprToString(e.X)
+	case *ast.UnaryExpr:
+		return e.Op.String() + exprToString(e.X)
+	case *ast.BinaryExpr:
+		return exprToString(e.X) + " " + e.Op.String() + " " + exprToString(e.Y)
+	case *ast.CallExpr:
+		var args []string
+		for _, arg := range e.Args {
+			args = append(args, exprToString(arg))
+		}
+		return exprToString(e.Fun) + "(" + strings.Join(args, ", ") + ")"
+	case *ast.ParenExpr:
+		return "(" + exprToString(e.X) + ")"
+	case *ast.IndexExpr:
+		return exprToString(e.X) + "[" + exprToString(e.Index) + "]"
+	case *ast.BasicLit:
+		return e.Value
+	case *ast.TypeAssertExpr:
+		return exprToString(e.X) + ".(" + exprToString(e.Type) + ")"
+	default:
+		// If we can't handle the expression type, return a placeholder
+		return fmt.Sprintf("/* complex expression */")
+	}
 }
 
 func isNil(ex ast.Expr) bool {
@@ -322,10 +466,91 @@ func LintErrorTypeAssertions(fset *token.FileSet, info *TypesInfoExt) []analysis
 			continue
 		}
 
-		lints = append(lints, analysis.Diagnostic{
+		diagnostic := analysis.Diagnostic{
 			Message: "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors",
 			Pos:     typeAssert.Pos(),
-		})
+		}
+
+		// Create suggested fix for type assertion
+		targetType := exprToString(typeAssert.Type)
+		errExpr := exprToString(typeAssert.X)
+
+		parent := info.NodeParent[typeAssert]
+
+		// For assignment statements like: targetErr, ok := err.(*SomeError)
+		if assign, ok := parent.(*ast.AssignStmt); ok && len(assign.Lhs) == 2 {
+			if id, ok := assign.Lhs[0].(*ast.Ident); ok {
+				varName := id.Name
+
+				// If this is part of an if statement initialization
+				ifParent, isIfInit := info.NodeParent[assign].(*ast.IfStmt)
+				if isIfInit && ifParent.Init == assign {
+					// Handle special case for if statements
+					// Replace: if targetErr, ok := err.(*SomeError); ok {
+					// With:    if targetErr := new(SomeError); errors.As(err, targetErr) {
+
+					// Get the condition of the if statement (usually just "ok")
+					replacement := fmt.Sprintf("%s := new(%s);\nerrors.As(%s, %s)",
+						varName, targetType[1:], // Remove the leading * from the type name
+						errExpr, varName)
+
+					diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+						Message: "Use errors.As() for type assertions on errors",
+						TextEdits: []analysis.TextEdit{{
+							Pos:     assign.Pos(),
+							End:     ifParent.Cond.End(),
+							NewText: []byte(replacement),
+						}},
+					}}
+				} else {
+					// Regular assignment outside of if statement
+					// Replace: targetErr, ok := err.(*SomeError)
+					// With:    targetErr := new(SomeError); ok := errors.As(err, targetErr)
+					replacement := fmt.Sprintf("%s := new(%s)\nok := errors.As(%s, %s)",
+						varName, targetType[1:], // Remove the leading * from the type name
+						errExpr, varName)
+
+					diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+						Message: "Use errors.As() for type assertions on errors",
+						TextEdits: []analysis.TextEdit{{
+							Pos:     assign.Pos(),
+							End:     assign.End(),
+							NewText: []byte(replacement),
+						}},
+					}}
+				}
+			}
+		} else if _, ok := parent.(*ast.IfStmt); ok {
+			// For if statements without initialization but with direct type assertion in condition
+			// This case is less common but could happen
+			replacement := fmt.Sprintf("var target %s\nerrors.As(%s, &target)",
+				targetType, errExpr)
+
+			diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+				Message: "Use errors.As() for type assertions on errors",
+				TextEdits: []analysis.TextEdit{{
+					Pos:     typeAssert.Pos(),
+					End:     typeAssert.End(),
+					NewText: []byte(replacement),
+				}},
+			}}
+		} else {
+			// For standalone type assertions: err.(*SomeError)
+			// Create an anonymous function that handles the errors.As call
+			replacement := fmt.Sprintf("func() %s {\n\tvar target %s\n\t_ = errors.As(%s, &target)\n\treturn target\n}()",
+				targetType, targetType, errExpr)
+
+			diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+				Message: "Use errors.As() for type assertions on errors",
+				TextEdits: []analysis.TextEdit{{
+					Pos:     typeAssert.Pos(),
+					End:     typeAssert.End(),
+					NewText: []byte(replacement),
+				}},
+			}}
+		}
+
+		lints = append(lints, diagnostic)
 	}
 
 	for scope := range info.TypesInfo.Scopes {
@@ -353,10 +578,163 @@ func LintErrorTypeAssertions(fset *token.FileSet, info *TypesInfoExt) []analysis
 			continue
 		}
 
-		lints = append(lints, analysis.Diagnostic{
+		diagnostic := analysis.Diagnostic{
 			Message: "type switch on error will fail on wrapped errors. Use errors.As to check for specific errors",
 			Pos:     typeAssert.Pos(),
-		})
+		}
+
+		// Transform type switch into a switch statement with errors.As in each case
+		// e.g., switch err.(type) { case *MyError: ... } becomes:
+		// var myError *MyError; switch { case errors.As(err, &myError): ... }
+
+		// Get the error variable being type-switched on
+		errExpr := typeAssert.X
+
+		// Determine if this is a type switch with assignment (switch e := err.(type))
+		var assignIdent *ast.Ident
+		var useShadowVar bool
+		if assignStmt, ok := typeSwitch.Assign.(*ast.AssignStmt); ok {
+			// This is a type switch with assignment like: switch e := err.(type)
+			if len(assignStmt.Lhs) == 1 {
+				if id, ok := assignStmt.Lhs[0].(*ast.Ident); ok {
+					assignIdent = id
+					useShadowVar = true
+				}
+			}
+		}
+
+		// Create variable declarations for each type
+		varDecls := []ast.Stmt{}
+
+		// Create a map of type expressions to variable names
+		typeToVar := make(map[ast.Expr]string)
+
+		// First collect all unique types from cases
+		caseTypes := []ast.Expr{}
+		for _, stmt := range typeSwitch.Body.List {
+			caseClause := stmt.(*ast.CaseClause)
+			for _, typeExpr := range caseClause.List {
+				// Skip default case (empty list)
+				if typeExpr != nil {
+					caseTypes = append(caseTypes, typeExpr)
+				}
+			}
+		}
+
+		// Create variable declarations for each type
+		for i, typeExpr := range caseTypes {
+			var varName string
+			if useShadowVar {
+				// If we have an assignment identifier, use it for all variables in a switch with assignment
+				varName = assignIdent.Name
+			} else if assignIdent != nil && i == 0 {
+				// Otherwise, if we have an assignment but not shadowing, use it for the first variable
+				varName = assignIdent.Name
+			} else {
+				// Otherwise generate a unique name
+				varName = fmt.Sprintf("err_case_%d", i)
+			}
+
+			// Record the mapping from type to variable name
+			typeToVar[typeExpr] = varName
+
+			// Only add the variable declaration if we haven't added it already
+			// (to avoid duplicate declarations for the same variable name)
+			alreadyDeclared := false
+			for j := 0; j < i; j++ {
+				if typeToVar[caseTypes[j]] == varName {
+					alreadyDeclared = true
+					break
+				}
+			}
+
+			if !alreadyDeclared {
+				// Create a variable declaration
+				varDecl := &ast.DeclStmt{
+					Decl: &ast.GenDecl{
+						Tok: token.VAR,
+						Specs: []ast.Spec{
+							&ast.ValueSpec{
+								Names: []*ast.Ident{ast.NewIdent(varName)},
+								Type:  typeExpr,
+							},
+						},
+					},
+				}
+
+				varDecls = append(varDecls, varDecl)
+			}
+		}
+
+		// Create a new switch statement with empty tag
+		newSwitchStmt := &ast.SwitchStmt{
+			Body: &ast.BlockStmt{
+				List: make([]ast.Stmt, len(typeSwitch.Body.List)),
+			},
+		}
+
+		// Create a block statement to hold both variable declarations and the switch
+		blockStmt := &ast.BlockStmt{
+			List: append(varDecls, newSwitchStmt),
+		}
+
+		// Process each case
+		for i, stmt := range typeSwitch.Body.List {
+			caseClause := stmt.(*ast.CaseClause)
+
+			// Create a new case clause
+			newCaseClause := &ast.CaseClause{
+				Body: caseClause.Body,
+			}
+
+			// If this is a default case, keep it as-is
+			if len(caseClause.List) == 0 {
+				// This is the default case
+				newCaseClause.List = nil
+			} else {
+				// For other cases, create errors.As calls for each type
+				newCaseClause.List = make([]ast.Expr, len(caseClause.List))
+
+				for j, typeExpr := range caseClause.List {
+					// Get the previously declared variable for this type
+					varName := typeToVar[typeExpr]
+
+					// Create errors.As(err, &varName) call
+					newCaseClause.List[j] = &ast.CallExpr{
+						Fun: &ast.SelectorExpr{
+							X:   ast.NewIdent("errors"),
+							Sel: ast.NewIdent("As"),
+						},
+						Args: []ast.Expr{
+							errExpr,
+							&ast.UnaryExpr{
+								Op: token.AND,
+								X:  ast.NewIdent(varName),
+							},
+						},
+					}
+				}
+			}
+
+			// Add this case to the switch
+			newSwitchStmt.Body.List[i] = newCaseClause
+		}
+
+		// Print the resulting block to get the fix text
+		var buf bytes.Buffer
+		printer.Fprint(&buf, token.NewFileSet(), blockStmt)
+		fixText := buf.String()
+
+		diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+			Message: "Convert type switch to use errors.As",
+			TextEdits: []analysis.TextEdit{{
+				Pos:     typeSwitch.Pos(),
+				End:     typeSwitch.End(),
+				NewText: []byte(fixText),
+			}},
+		}}
+
+		lints = append(lints, diagnostic)
 	}
 
 	return lints

--- a/errorlint/testdata/src/errorassert/errorassert.go
+++ b/errorlint/testdata/src/errorassert/errorassert.go
@@ -1,0 +1,93 @@
+package errorassert
+
+import (
+	"errors"
+	"fmt"
+)
+
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my custom error"
+}
+
+type AnotherError struct{}
+
+func (*AnotherError) Error() string {
+	return "another error"
+}
+
+func doSomething() error {
+	return &MyError{}
+}
+
+func doSomethingWrapped() error {
+	return fmt.Errorf("wrapped: %w", &MyError{})
+}
+
+// This should be flagged - direct type assertion
+func TypeAssertionDirect() {
+	err := doSomething()
+	me, ok := err.(*MyError) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type assertion in a simple assignment
+func TypeAssertionAssignment() {
+	err := doSomething()
+	myErr, ok := err.(*MyError) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	fmt.Println(myErr, ok)
+}
+
+// This should be flagged - type assertion in if statement
+func TypeAssertionInIf() {
+	err := doSomething()
+	if me, ok := err.(*MyError); ok { // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type switch
+func TypeSwitchStatement() {
+	err := doSomething()
+	switch err.(type) { // want "type switch on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	case *MyError:
+		fmt.Println("my error")
+	case *AnotherError:
+		fmt.Println("another error")
+	default:
+		fmt.Println("unknown error")
+	}
+}
+
+// This should be flagged - type switch with assignment
+func TypeSwitchWithAssignment() {
+	err := doSomething()
+	switch e := err.(type) { // want "type switch on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	case *MyError:
+		fmt.Println("my error:", e)
+	case *AnotherError:
+		fmt.Println("another error:", e)
+	default:
+		fmt.Println("unknown error:", e)
+	}
+}
+
+// This should NOT be flagged - using errors.As
+func UsingErrorsAs() {
+	err := doSomethingWrapped()
+	var me *MyError
+	if errors.As(err, &me) {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should NOT be flagged - non-error type assertion
+func NonErrorTypeAssertion() {
+	var i interface{} = "hello"
+	if s, ok := i.(string); ok {
+		fmt.Println(s)
+	}
+}

--- a/errorlint/testdata/src/errorassert/errorassert.go.golden
+++ b/errorlint/testdata/src/errorassert/errorassert.go.golden
@@ -24,6 +24,23 @@ func (ValueError) Error() string {
 	return "value error"
 }
 
+// CustomUnwrapError demonstrates custom unwrap implementation
+type CustomUnwrapError struct {
+	inner error
+}
+
+func (e *CustomUnwrapError) Error() string { return "custom: " + e.inner.Error() }
+func (e *CustomUnwrapError) Unwrap() error { return e.inner }
+
+// CustomIsError demonstrates custom Is implementation
+type CustomIsError struct{}
+
+func (*CustomIsError) Error() string { return "custom is error" }
+func (*CustomIsError) Is(target error) bool {
+	_, ok := target.(*MyError)
+	return ok
+}
+
 func doSomething() error {
 	return &MyError{}
 }
@@ -38,6 +55,18 @@ func doSomethingValueError() error {
 
 func doSomethingValueWrapped() error {
 	return fmt.Errorf("wrapped value: %w", ValueError{})
+}
+
+func getCustomUnwrapError() error {
+	return &CustomUnwrapError{inner: &MyError{}}
+}
+
+func getCustomIsError() error {
+	return &CustomIsError{}
+}
+
+func deepWrappedError() error {
+	return fmt.Errorf("level1: %w", fmt.Errorf("level2: %w", &MyError{}))
 }
 
 // This should be flagged - direct type assertion
@@ -168,5 +197,62 @@ func NonErrorTypeAssertion() {
 	var i interface{} = "hello"
 	if s, ok := i.(string); ok {
 		fmt.Println(s)
+	}
+}
+
+// This should be flagged - type assertion on an error with custom unwrap
+func TypeAssertCustomUnwrap() {
+	err := getCustomUnwrapError()
+	me := &MyError{}
+	ok := errors.As(err, &me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type assertion on deeply wrapped error
+func TypeAssertDeepWrapped() {
+	err := deepWrappedError()
+	me := &MyError{}
+	ok := errors.As(err, &me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type assertion on error with custom Is method
+func TypeAssertCustomIs() {
+	err := getCustomIsError()
+	me := &MyError{}
+	ok := errors.As(err, &me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This tests the error conversion case
+func ErrorConversion() {
+	var err error = &MyError{}
+	var iface interface{} = err
+
+	// This should NOT be flagged - not asserting on an error type
+	_, ok1 := iface.(*MyError)
+
+	// This should be flagged - asserting on an error type
+	myError := &MyError{}
+	ok2 := errors.As(err, &myError) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+
+	fmt.Println(ok1, ok2)
+}
+
+// This should NOT be flagged - using errors.As with a pointer to a pointer
+func UsingErrorsAsWithPointerToPointer() {
+	var err error = &MyError{}
+
+	me := new(*MyError)
+	if errors.As(err, me) {
+		fmt.Println(me)
+	} else {
+		fmt.Println("-")
 	}
 }

--- a/errorlint/testdata/src/errorassert/errorassert.go.golden
+++ b/errorlint/testdata/src/errorassert/errorassert.go.golden
@@ -1,0 +1,102 @@
+package errorassert
+
+import (
+	"errors"
+	"fmt"
+)
+
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my custom error"
+}
+
+type AnotherError struct{}
+
+func (*AnotherError) Error() string {
+	return "another error"
+}
+
+func doSomething() error {
+	return &MyError{}
+}
+
+func doSomethingWrapped() error {
+	return fmt.Errorf("wrapped: %w", &MyError{})
+}
+
+// This should be flagged - direct type assertion
+func TypeAssertionDirect() {
+	err := doSomething()
+	me := new(MyError)
+	ok := errors.As(err, me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type assertion in a simple assignment
+func TypeAssertionAssignment() {
+	err := doSomething()
+	myErr := new(MyError)
+	ok := errors.As(err, myErr) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	fmt.Println(myErr, ok)
+}
+
+// This should be flagged - type assertion in if statement
+func TypeAssertionInIf() {
+	err := doSomething()
+	if me := new(MyError); errors.As(err, me) { // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should be flagged - type switch
+func TypeSwitchStatement() {
+	err := doSomething()
+	{
+		var err_case_0 *MyError
+		var err_case_1 *AnotherError
+		switch {
+		case errors.As(err, &err_case_0):
+			fmt.Println("my error")
+		case errors.As(err, &err_case_1):
+			fmt.Println("another error")
+		default:
+			fmt.Println("unknown error")
+		}
+	}
+}
+
+// This should be flagged - type switch with assignment
+func TypeSwitchWithAssignment() {
+	err := doSomething()
+	{
+		var e *MyError
+		switch {
+		case errors.As(err, &e):
+			fmt.Println("my error:", e)
+		case errors.As(err, &e):
+			fmt.Println("another error:", e)
+		default:
+			fmt.Println("unknown error:", e)
+		}
+	}
+}
+
+// This should NOT be flagged - using errors.As
+func UsingErrorsAs() {
+	err := doSomethingWrapped()
+	var me *MyError
+	if errors.As(err, &me) {
+		fmt.Println("got my error:", me)
+	}
+}
+
+// This should NOT be flagged - non-error type assertion
+func NonErrorTypeAssertion() {
+	var i interface{} = "hello"
+	if s, ok := i.(string); ok {
+		fmt.Println(s)
+	}
+}

--- a/errorlint/testdata/src/errorassert/errorassert.go.golden
+++ b/errorlint/testdata/src/errorassert/errorassert.go.golden
@@ -17,6 +17,13 @@ func (*AnotherError) Error() string {
 	return "another error"
 }
 
+// ValueError implements error with a value receiver, not a pointer receiver
+type ValueError struct{}
+
+func (ValueError) Error() string {
+	return "value error"
+}
+
 func doSomething() error {
 	return &MyError{}
 }
@@ -25,11 +32,19 @@ func doSomethingWrapped() error {
 	return fmt.Errorf("wrapped: %w", &MyError{})
 }
 
+func doSomethingValueError() error {
+	return ValueError{}
+}
+
+func doSomethingValueWrapped() error {
+	return fmt.Errorf("wrapped value: %w", ValueError{})
+}
+
 // This should be flagged - direct type assertion
 func TypeAssertionDirect() {
 	err := doSomething()
-	me := new(MyError)
-	ok := errors.As(err, me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	me := &MyError{}
+	ok := errors.As(err, &me) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
 	if ok {
 		fmt.Println("got my error:", me)
 	}
@@ -38,30 +53,75 @@ func TypeAssertionDirect() {
 // This should be flagged - type assertion in a simple assignment
 func TypeAssertionAssignment() {
 	err := doSomething()
-	myErr := new(MyError)
-	ok := errors.As(err, myErr) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	myErr := &MyError{}
+	ok := errors.As(err, &myErr) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
 	fmt.Println(myErr, ok)
 }
 
 // This should be flagged - type assertion in if statement
 func TypeAssertionInIf() {
 	err := doSomething()
-	if me := new(MyError); errors.As(err, me) { // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	me := &MyError{}
+	if errors.As(err, &me) { // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
 		fmt.Println("got my error:", me)
 	}
+}
+
+// This should be flagged - value type assertion in if statement
+func ValueTypeAssertionInIf() {
+	err := doSomethingValueError()
+	var ve ValueError
+	if errors.As(err, &ve) { // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+		fmt.Println("got value error:", ve)
+	}
+}
+
+// This should be flagged - value type assertion in assignment
+func ValueTypeAssertionAssignment() {
+	err := doSomethingValueError()
+	var ve ValueError
+	ok := errors.As(err, &ve) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	fmt.Println(ve, ok)
+}
+
+// This should be flagged - direct value type assertion
+func ValueTypeAssertionDirect() {
+	err := doSomethingValueError()
+	_ = func() ValueError {
+		var target ValueError
+		_ = errors.As(err, &target)
+		return target
+	}() // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
 }
 
 // This should be flagged - type switch
 func TypeSwitchStatement() {
 	err := doSomething()
 	{
-		var err_case_0 *MyError
-		var err_case_1 *AnotherError
+		var errCase0 *MyError
+		var errCase1 *AnotherError
 		switch {
-		case errors.As(err, &err_case_0):
+		case errors.As(err, &errCase0):
 			fmt.Println("my error")
-		case errors.As(err, &err_case_1):
+		case errors.As(err, &errCase1):
 			fmt.Println("another error")
+		default:
+			fmt.Println("unknown error")
+		}
+	}
+}
+
+// This should be flagged - type switch with value type
+func TypeSwitchWithValueType() {
+	err := doSomethingValueError()
+	{
+		var errCase0 ValueError
+		var errCase1 *MyError
+		switch {
+		case errors.As(err, &errCase0):
+			fmt.Println("value error")
+		case errors.As(err, &errCase1):
+			fmt.Println("my error")
 		default:
 			fmt.Println("unknown error")
 		}
@@ -73,11 +133,12 @@ func TypeSwitchWithAssignment() {
 	err := doSomething()
 	{
 		var e *MyError
+		var e1 *AnotherError
 		switch {
 		case errors.As(err, &e):
 			fmt.Println("my error:", e)
-		case errors.As(err, &e):
-			fmt.Println("another error:", e)
+		case errors.As(err, &e1):
+			fmt.Println("another error:", e1)
 		default:
 			fmt.Println("unknown error:", e)
 		}
@@ -90,6 +151,15 @@ func UsingErrorsAs() {
 	var me *MyError
 	if errors.As(err, &me) {
 		fmt.Println("got my error:", me)
+	}
+}
+
+// This should NOT be flagged - using errors.As with value type
+func UsingErrorsAsWithValueType() {
+	err := doSomethingValueWrapped()
+	var ve ValueError
+	if errors.As(err, &ve) {
+		fmt.Println("got value error:", ve)
 	}
 }
 

--- a/errorlint/testdata/src/errorcompare/errorcompare.go
+++ b/errorlint/testdata/src/errorcompare/errorcompare.go
@@ -20,6 +20,33 @@ func doAnotherThing() error {
 	return io.EOF
 }
 
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my custom error"
+}
+
+// CustomUnwrapError demonstrates custom unwrap implementation
+type CustomUnwrapError struct {
+	inner error
+}
+
+func (e *CustomUnwrapError) Error() string { return "custom: " + e.inner.Error() }
+func (e *CustomUnwrapError) Unwrap() error { return e.inner }
+
+// CustomIsError demonstrates custom Is implementation
+type CustomIsError struct{}
+
+func (*CustomIsError) Error() string { return "custom is error" }
+func (*CustomIsError) Is(target error) bool {
+	_, ok := target.(*MyError)
+	return ok
+}
+
+func getCustomIsError() error {
+	return &CustomIsError{}
+}
+
 // This should be flagged - direct comparison with ==
 func CompareWithEquals() {
 	err := doSomething()
@@ -129,5 +156,13 @@ func SwitchOnNonErrorValue() {
 		fmt.Println("Not Found")
 	default:
 		fmt.Println("Unknown status")
+	}
+}
+
+// This should NOT be flagged - using errors.Is with custom Is method
+func UsingErrorsIsWithCustomIs() {
+	err := getCustomIsError()
+	if errors.Is(err, &MyError{}) {
+		fmt.Println("is my error")
 	}
 }

--- a/errorlint/testdata/src/errorcompare/errorcompare.go
+++ b/errorlint/testdata/src/errorcompare/errorcompare.go
@@ -1,0 +1,133 @@
+package errorcompare
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+var ErrSentinel = errors.New("sentinel error")
+
+func doSomething() error {
+	return ErrSentinel
+}
+
+func doSomethingElse() error {
+	return fmt.Errorf("wrapped: %w", ErrSentinel)
+}
+
+func doAnotherThing() error {
+	return io.EOF
+}
+
+// This should be flagged - direct comparison with ==
+func CompareWithEquals() {
+	err := doSomething()
+	if err == ErrSentinel { // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+		fmt.Println("sentinel error")
+	}
+}
+
+// This should be flagged - direct comparison with !=
+func CompareWithNotEquals() {
+	err := doSomething()
+	if err != ErrSentinel { // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+		fmt.Println("not sentinel error")
+	}
+}
+
+// This should be flagged - direct comparison with == in binary expression
+func CompareInBinaryExpr() {
+	err := doSomething()
+	cond1 := err == ErrSentinel // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := err == io.EOF      // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+	if cond1 || cond2 {
+		fmt.Println("known error")
+	}
+}
+
+// This should be flagged - direct comparison with != in binary expression
+func CompareInBinaryExprNotEquals() {
+	err := doSomething()
+	cond1 := err != ErrSentinel // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := err != io.EOF      // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+	if cond1 && cond2 {
+		fmt.Println("unknown error")
+	}
+}
+
+// This should NOT be flagged - using errors.Is
+func CompareWithErrorsIs() {
+	err := doSomethingElse()
+	if errors.Is(err, ErrSentinel) {
+		fmt.Println("sentinel error (wrapped)")
+	}
+}
+
+// This should NOT be flagged - nil comparison
+func CompareWithNil() {
+	err := doSomething()
+	if err == nil {
+		fmt.Println("no error")
+	}
+}
+
+// This should NOT be flagged - nil comparison with !=
+func CompareWithNotNil() {
+	err := doSomething()
+	if err != nil {
+		fmt.Println("has error")
+	}
+}
+
+// This should be flagged - direct comparison in switch statement
+func CompareInSwitch() {
+	err := doSomething()
+	switch err {
+	case ErrSentinel: // want "switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors"
+		fmt.Println("sentinel error")
+	case io.EOF:
+		fmt.Println("EOF error")
+	default:
+		fmt.Println("unknown error")
+	}
+}
+
+// This should be flagged - direct comparison in switch with assignment
+func CompareInSwitchWithAssignment() {
+	err := doSomething()
+	switch e := err; e {
+	case ErrSentinel: // want "switch on an error will fail on wrapped errors. Use errors.Is to check for specific errors"
+		fmt.Println("sentinel error:", e)
+	case io.EOF:
+		fmt.Println("EOF error:", e)
+	default:
+		fmt.Println("unknown error:", e)
+	}
+}
+
+// This should NOT be flagged - using proper errors.Is in each case
+func CompareInSwitchWithErrorsIs() {
+	err := doSomething()
+	switch {
+	case errors.Is(err, ErrSentinel):
+		fmt.Println("sentinel error")
+	case errors.Is(err, io.EOF):
+		fmt.Println("EOF error")
+	default:
+		fmt.Println("unknown error")
+	}
+}
+
+// This should NOT be flagged - switch on non-error value
+func SwitchOnNonErrorValue() {
+	code := 404
+	switch code {
+	case 200:
+		fmt.Println("OK")
+	case 404:
+		fmt.Println("Not Found")
+	default:
+		fmt.Println("Unknown status")
+	}
+}

--- a/errorlint/testdata/src/errorcompare/errorcompare.go.golden
+++ b/errorlint/testdata/src/errorcompare/errorcompare.go.golden
@@ -20,6 +20,33 @@ func doAnotherThing() error {
 	return io.EOF
 }
 
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my custom error"
+}
+
+// CustomUnwrapError demonstrates custom unwrap implementation
+type CustomUnwrapError struct {
+	inner error
+}
+
+func (e *CustomUnwrapError) Error() string { return "custom: " + e.inner.Error() }
+func (e *CustomUnwrapError) Unwrap() error { return e.inner }
+
+// CustomIsError demonstrates custom Is implementation
+type CustomIsError struct{}
+
+func (*CustomIsError) Error() string { return "custom is error" }
+func (*CustomIsError) Is(target error) bool {
+	_, ok := target.(*MyError)
+	return ok
+}
+
+func getCustomIsError() error {
+	return &CustomIsError{}
+}
+
 // This should be flagged - direct comparison with ==
 func CompareWithEquals() {
 	err := doSomething()
@@ -40,7 +67,7 @@ func CompareWithNotEquals() {
 func CompareInBinaryExpr() {
 	err := doSomething()
 	cond1 := errors.Is(err, ErrSentinel) // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
-	cond2 := errors.Is(err, io.EOF) // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := errors.Is(err, io.EOF)      // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
 	if cond1 || cond2 {
 		fmt.Println("known error")
 	}
@@ -50,7 +77,7 @@ func CompareInBinaryExpr() {
 func CompareInBinaryExprNotEquals() {
 	err := doSomething()
 	cond1 := !errors.Is(err, ErrSentinel) // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
-	cond2 := !errors.Is(err, io.EOF) // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := !errors.Is(err, io.EOF)      // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
 	if cond1 && cond2 {
 		fmt.Println("unknown error")
 	}
@@ -79,6 +106,7 @@ func CompareWithNotNil() {
 		fmt.Println("has error")
 	}
 }
+
 // This should be flagged - direct comparison in switch statement
 func CompareInSwitch() {
 	err := doSomething()
@@ -128,5 +156,13 @@ func SwitchOnNonErrorValue() {
 		fmt.Println("Not Found")
 	default:
 		fmt.Println("Unknown status")
+	}
+}
+
+// This should NOT be flagged - using errors.Is with custom Is method
+func UsingErrorsIsWithCustomIs() {
+	err := getCustomIsError()
+	if errors.Is(err, &MyError{}) {
+		fmt.Println("is my error")
 	}
 }

--- a/errorlint/testdata/src/errorcompare/errorcompare.go.golden
+++ b/errorlint/testdata/src/errorcompare/errorcompare.go.golden
@@ -1,0 +1,132 @@
+package errorcompare
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+var ErrSentinel = errors.New("sentinel error")
+
+func doSomething() error {
+	return ErrSentinel
+}
+
+func doSomethingElse() error {
+	return fmt.Errorf("wrapped: %w", ErrSentinel)
+}
+
+func doAnotherThing() error {
+	return io.EOF
+}
+
+// This should be flagged - direct comparison with ==
+func CompareWithEquals() {
+	err := doSomething()
+	if errors.Is(err, ErrSentinel) { // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+		fmt.Println("sentinel error")
+	}
+}
+
+// This should be flagged - direct comparison with !=
+func CompareWithNotEquals() {
+	err := doSomething()
+	if !errors.Is(err, ErrSentinel) { // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+		fmt.Println("not sentinel error")
+	}
+}
+
+// This should be flagged - direct comparison with == in binary expression
+func CompareInBinaryExpr() {
+	err := doSomething()
+	cond1 := errors.Is(err, ErrSentinel) // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := errors.Is(err, io.EOF) // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+	if cond1 || cond2 {
+		fmt.Println("known error")
+	}
+}
+
+// This should be flagged - direct comparison with != in binary expression
+func CompareInBinaryExprNotEquals() {
+	err := doSomething()
+	cond1 := !errors.Is(err, ErrSentinel) // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+	cond2 := !errors.Is(err, io.EOF) // want "comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error"
+	if cond1 && cond2 {
+		fmt.Println("unknown error")
+	}
+}
+
+// This should NOT be flagged - using errors.Is
+func CompareWithErrorsIs() {
+	err := doSomethingElse()
+	if errors.Is(err, ErrSentinel) {
+		fmt.Println("sentinel error (wrapped)")
+	}
+}
+
+// This should NOT be flagged - nil comparison
+func CompareWithNil() {
+	err := doSomething()
+	if err == nil {
+		fmt.Println("no error")
+	}
+}
+
+// This should NOT be flagged - nil comparison with !=
+func CompareWithNotNil() {
+	err := doSomething()
+	if err != nil {
+		fmt.Println("has error")
+	}
+}
+// This should be flagged - direct comparison in switch statement
+func CompareInSwitch() {
+	err := doSomething()
+	switch {
+	case errors.Is(err, ErrSentinel):
+		fmt.Println("sentinel error")
+	case errors.Is(err, io.EOF):
+		fmt.Println("EOF error")
+	default:
+		fmt.Println("unknown error")
+	}
+}
+
+// This should be flagged - direct comparison in switch with assignment
+func CompareInSwitchWithAssignment() {
+	err := doSomething()
+	switch e := err; {
+	case errors.Is(e, ErrSentinel):
+		fmt.Println("sentinel error:", e)
+	case errors.Is(e, io.EOF):
+		fmt.Println("EOF error:", e)
+	default:
+		fmt.Println("unknown error:", e)
+	}
+}
+
+// This should NOT be flagged - using proper errors.Is in each case
+func CompareInSwitchWithErrorsIs() {
+	err := doSomething()
+	switch {
+	case errors.Is(err, ErrSentinel):
+		fmt.Println("sentinel error")
+	case errors.Is(err, io.EOF):
+		fmt.Println("EOF error")
+	default:
+		fmt.Println("unknown error")
+	}
+}
+
+// This should NOT be flagged - switch on non-error value
+func SwitchOnNonErrorValue() {
+	code := 404
+	switch code {
+	case 200:
+		fmt.Println("OK")
+	case 404:
+		fmt.Println("Not Found")
+	default:
+		fmt.Println("Unknown status")
+	}
+}


### PR DESCRIPTION
This is an attempt to add auto-fixes for error comparisons. By all means, I'm no expert on the topic. Please let me know what I don't know. I would love to have this functionality to fix large codebases. I'm all open to iterate on this an improve the implementation. I'm opening it as soon as the tests pass so it could be in a rather rough shape.

## Changes

Enhance errorlint analyzer with automatic fixes for:
- Error comparisons using `==` and `!=`
- Type assertions on errors
- Error switches

Adds suggested fixes to:
- Replace direct error comparisons with `errors.Is()`
- Convert type assertions to use `errors.As()`
- Transform error switches to use `errors.Is()` and `errors.As()`

Includes new test cases and golden files to validate the new automatic fixing capabilities.
