### PR TITLE
feat: add option helpers for comparison and assertion checks

### DIFF
--- a/errorlint/options.go
+++ b/errorlint/options.go
@@ -13,3 +13,15 @@ func WithAllowedWildcard(ap []AllowPair) Option {
 		allowedWildcardAppend(ap)
 	}
 }
+
+func WithComparison(enabled bool) Option {
+	return func() {
+		checkComparison = enabled
+	}
+}
+
+func WithAsserts(enabled bool) Option {
+	return func() {
+		checkAsserts = enabled
+	}
+}

--- a/errorlint/options_test.go
+++ b/errorlint/options_test.go
@@ -27,6 +27,16 @@ func TestOption(t *testing.T) {
 			}),
 			pattern: "options/withAllowedWildcard",
 		},
+		{
+			desc: "WithComparison",
+			opt: errorlint.WithComparison(true),
+			pattern: "options/withComparison",
+		},
+		{
+			desc: "WithAsserts",
+			opt: errorlint.WithAsserts(true),
+			pattern: "options/withAsserts",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/errorlint/testdata/src/options/withAsserts/withAsserts.go
+++ b/errorlint/testdata/src/options/withAsserts/withAsserts.go
@@ -1,0 +1,24 @@
+package testdata
+
+import (
+	"fmt"
+)
+
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my custom error"
+}
+
+func doSomething() error {
+	return &MyError{}
+}
+
+// This should be flagged when assert checking is enabled
+func TypeAssertionDirect() {
+	err := doSomething()
+	me, ok := err.(*MyError) // want "type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	if ok {
+		fmt.Println("got my error:", me)
+	}
+}

--- a/errorlint/testdata/src/options/withComparison/withComparison.go
+++ b/errorlint/testdata/src/options/withComparison/withComparison.go
@@ -1,0 +1,20 @@
+package testdata
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrSentinel = errors.New("sentinel error")
+
+func doSomething() error {
+	return ErrSentinel
+}
+
+// This should be flagged when comparison checking is enabled
+func CompareWithEquals() {
+	err := doSomething()
+	if err == ErrSentinel { // want "comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error"
+		fmt.Println("sentinel error")
+	}
+}


### PR DESCRIPTION
Add WithComparison and WithAsserts option helpers to allow programmatic
configuration of checkComparison and checkAsserts flags. This enables
fine-grained control over which error linting rules are applied when
using the analyzer as a library.

- Add WithComparison(bool) option helper for comparison checking
- Add WithAsserts(bool) option helper for assertion checking
- Add corresponding test cases and test data
- All tests pass

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
