### PR TITLE
fix: type assertion can reuse existing error variable

### DIFF
--- a/errorlint/testdata/src/errorassert/errorassert.go
+++ b/errorlint/testdata/src/errorassert/errorassert.go
@@ -155,6 +155,17 @@ func TypeSwitchWithAssignment() {
 	}
 }
 
+// This should be flagged - type switch with assignment reuse
+func TypeSwitchWithAssignmentReuse() {
+	err := doSomething()
+	switch err := err.(type) { // want "type switch on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	case *MyError:
+		fmt.Println("my error:", err)
+	default:
+		fmt.Println("unknown error:", err)
+	}
+}
+
 // This should NOT be flagged - using errors.As
 func UsingErrorsAs() {
 	err := doSomethingWrapped()

--- a/errorlint/testdata/src/errorassert/errorassert.go.golden
+++ b/errorlint/testdata/src/errorassert/errorassert.go.golden
@@ -176,6 +176,17 @@ func TypeSwitchWithAssignment() {
 	}
 }
 
+// This should be flagged - type switch with assignment reuse
+func TypeSwitchWithAssignmentReuse() {
+	err := doSomething()
+	switch err := err.(type) { // want "type switch on error will fail on wrapped errors. Use errors.As to check for specific errors"
+	case *MyError:
+		fmt.Println("my error:", err)
+	default:
+		fmt.Println("unknown error:", err)
+	}
+}
+
 // This should NOT be flagged - using errors.As
 func UsingErrorsAs() {
 	err := doSomethingWrapped()


### PR DESCRIPTION
This is an edge case that can lead to invalid code.

This commit is basic, it prevents the linter to provide a fix that cannot work.

Related to #109 
